### PR TITLE
Adding an option to allow full-path patterns in pytest.

### DIFF
--- a/sybil/integration/pytest.py
+++ b/sybil/integration/pytest.py
@@ -116,7 +116,7 @@ class SybilFile(pytest.File):
             self.sybil.teardown(self.document.namespace)
 
 
-def pytest_integration(sybil):
+def pytest_integration(sybil, match_full_pattern):
 
     def pytest_collect_file(parent, path):
         if sybil.should_test_filename(path.basename):
@@ -126,5 +126,17 @@ def pytest_integration(sybil):
                 return SybilFile(path, parent, sybil)
             else:
                 return from_parent(parent, fspath=path, sybil=sybil)
+    
+    def pytest_collect_path(parent, path):
+        if sybil.should_test_filename(str(path)):
+            try:
+                from_parent = SybilFile.from_parent
+            except AttributeError:
+                return SybilFile(path, parent, sybil)
+            else:
+                return from_parent(parent, fspath=path, sybil=sybil)
 
-    return pytest_collect_file
+    if match_full_pattern:
+        return pytest_collect_path
+    else:
+        return pytest_collect_file

--- a/sybil/sybil.py
+++ b/sybil/sybil.py
@@ -95,12 +95,16 @@ class Sybil(object):
             if self.should_test_filename(filename):
                 yield self.parse(join(self.path, filename))
 
-    def pytest(self):
+    def pytest(self, match_full_pattern=False):
         """
         The helper method for when you use :ref:`pytest_integration`.
+        :param match_full_pattern:
+          Flag that changes the handling of patterns. By default Sybil uses only the basename part
+          of a pattern (e.g. `**/foo/*.rst` would only use `*.rst` as a pattern). Set this to True
+          to use the entire pattern.
         """
         from .integration.pytest import pytest_integration
-        return pytest_integration(self)
+        return pytest_integration(self, match_full_pattern)
 
     def unittest(self):
         """


### PR DESCRIPTION
I'd like to undo my kluge here: https://github.com/UAVCAN/nunavut/blob/master/conftest.py#L335

If you accept this patch it shouldn't change any existing uses. This is an "opt-in" change.